### PR TITLE
Output in real units (cgs for now) using the loader

### DIFF
--- a/src/simdata/loaders/PLUTO42.py
+++ b/src/simdata/loaders/PLUTO42.py
@@ -527,12 +527,12 @@ class FieldLoader2d(interface.FieldLoader):
                                dtype=float,
                                shape=(self.loader.NVAR, *file_format))
             rv = np.array(memmap[qty_info["numvar"]], dtype=float)
-            rv = (rv * unit).decompose().cgs
         else:
             rv = np.fromfile(filename).reshape(*file_format)
-            rv = (rv * unit).decompose().cgs
 
-        return rv
+        rv *= unit
+        
+        return rv.decompose().cgs
 
     def convert_data(self, n, qty=None):
         """Given a requested field (e.g. "temperature"), calculates said field using existing data.

--- a/src/simdata/loaders/PLUTO42.py
+++ b/src/simdata/loaders/PLUTO42.py
@@ -530,7 +530,7 @@ class FieldLoader2d(interface.FieldLoader):
         else:
             rv = np.fromfile(filename).reshape(*file_format)
 
-        rv *= unit
+        rv = rv * unit
         
         return rv.decompose().cgs
 

--- a/src/simdata/loaders/PLUTO_aux/PLUTOgrid.py
+++ b/src/simdata/loaders/PLUTO_aux/PLUTOgrid.py
@@ -123,25 +123,25 @@ def loadGrid(dataDir, length_unit=None, angle_unit=None):
         x_i = g[0].xi * length_unit
         y_i = g[1].xi * length_unit
         z_i = g[2].xi * length_unit
-        return grid.CartesianGrid(x_i=x_i,
-                                  y_i=y_i,
-                                  z_i=z_i,
+        return grid.CartesianGrid(x_i=x_i.decompose().cgs,
+                                  y_i=y_i.decompose().cgs,
+                                  z_i=z_i.decompose().cgs,
                                   active_interfaces=[])
     elif geometry == 'SPHERICAL':
         r_i = g[0].xi * length_unit
         theta_i = g[1].xi * angle_unit
         phi_i = g[2].xi * angle_unit
-        return grid.SphericalGrid(r_i=r_i,
-                                  theta_i=theta_i,
-                                  phi_i=phi_i,
+        return grid.SphericalGrid(r_i=r_i.decompose().cgs,
+                                  theta_i=theta_i.decompose().cgs,
+                                  phi_i=phi_i.decompose().cgs,
                                   active_interfaces=[])
     elif geometry == 'POLAR':
         r_i = g[0].xi * length_unit
         phi_i = g[1].xi * angle_unit
         z_i = g[2].xi * length_unit
-        return grid.CylindricalGrid(r_i=r_i,
-                                    phi_i=phi_i,
-                                    z_i=z_i,
+        return grid.CylindricalGrid(r_i=r_i.decompose().cgs,
+                                    phi_i=phi_i.decompose().cgs,
+                                    z_i=z_i.decompose().cgs,
                                     active_interfaces=[])
     elif geometry == 'CYLINDRICAL':
         raise Warning(
@@ -149,9 +149,9 @@ def loadGrid(dataDir, length_unit=None, angle_unit=None):
         r_i = g[0].xi * length_unit
         z_i = g[1].xi * length_unit
         phi_i = np.array([-1, 1], dtype=float)
-        return grid.CylindricalGrid(r_i=r_i,
-                                    phi_i=phi_i,
-                                    z_i=z_i,
+        return grid.CylindricalGrid(r_i=r_i.decompose().cgs,
+                                    phi_i=phi_i.decompose().cgs,
+                                    z_i=z_i.decompose().cgs,
                                     active_interfaces=[])
     else:
         raise ValueError('Impossible error. geometry = %s, dimensions = %s' %


### PR DESCRIPTION
Right now the loader outputs in the form [code unit] * [cgs unit]. I set the PLUTO branch so that it always outputs in cgs. Would be nice to have both options (also SI output would probably be useful):

> [code unit] * [cgs unit] exposes the actual output of the code, which is nice.
> cgs and SI are nice for plotting/handling data without calling .decompose().cgs every other line.

Something like d = Data(path, units='cgs/si', decompose=True) would be cool. Default should be decompose=False, and if set to True it should apply Quantity.decompose().cgs/si on loader level. 