### PR TITLE
Loader hints

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-if [[ "$#" == 1 ]]; then
+if [[ "$#" == 0 ]]; then
+	HOST="localhost"
+elif [[ "$#" == 1 ]]; then
 	HOST=$1
 else
 	echo "Wrong syntax! Usage: deploy.sh 'hostname'"
@@ -17,7 +19,14 @@ UUID="$(uuidgen)"
 REMOTE_TMP_DIR="/tmp/$UUID-install-$CODENAME"
 
 echo "Deploying '$CODENAME' on '$HOST'"
-# copy files
-rsync -r --exclude "src/*.egg-info" src setup.py $HOST:$REMOTE_TMP_DIR
-# install and clean up
-ssh $HOST "cd $REMOTE_TMP_DIR; python3 setup.py install --user; cd -; rm -rf $REMOTE_TMP_DIR" 1>/dev/null
+if [[ "$HOST" == "localhost" ]]; then
+	# copy files
+	rsync -r --exclude "src/*.egg-info" src setup.py $REMOTE_TMP_DIR
+	# install and clean up
+	sh -c "cd $REMOTE_TMP_DIR; python3 setup.py install --user; cd -; rm -rf $REMOTE_TMP_DIR" 1>/dev/null
+else
+	# copy files
+	rsync -r --exclude "src/*.egg-info" src setup.py $HOST:$REMOTE_TMP_DIR
+	# install and clean up
+	ssh $HOST "cd $REMOTE_TMP_DIR; python3 setup.py install --user; cd -; rm -rf $REMOTE_TMP_DIR" 1>/dev/null
+fi

--- a/src/simdata/loaders/__init__.py
+++ b/src/simdata/loaders/__init__.py
@@ -73,14 +73,16 @@ def get_loader(path, loader, **kwargs):
         Loader object to access data.
     """
     code = None
-    if loader is None:
-        choices = available
+    choices = available
     # check for direct specification of code
-    elif isinstance(loader, (tuple, list)):
-        for key, val in available.items():
-            if key == loader:
+    if isinstance(loader, (tuple, list)):
+        for key, mod in available.items():
+            if key == tuple(loader):
                 code = key
-                loader = val
+                try:
+                    loader = mod.Loader(path, **kwargs)
+                except Exception:
+                    code = None
                 break
     # check for simulation code names hints
     elif isinstance(loader, str):

--- a/src/simdata/loaders/__init__.py
+++ b/src/simdata/loaders/__init__.py
@@ -57,7 +57,38 @@ def identify_code(path, choices=available):
 
 
 def get_loader(path, loader, **kwargs):
-    if loader:
+    """
+    Get a loader for the simulation data inside path.
+
+    Parameters
+    ----------
+    path : str
+        Path to the data.
+    loader : str or :obj:`simdata.loaders.interface.Interface`
+        None or hint (str) or acutal loader for the data.
+
+    Returns
+    -------
+    simdata.loaders.interface.Interface
+        Loader object to access data.
+    """
+    code = None
+    if loader is None:
+        choices = available
+    # check for direct specification of code
+    elif isinstance(loader, (tuple, list)):
+        for key, val in available.items():
+            if key == loader:
+                code = key
+                loader = val
+                break
+    # check for simulation code names hints
+    elif isinstance(loader, str):
+        choices = { key : available[key] for key in available if loader in key[0] }
+        if len(choices) == 0:
+            choices = available
+    # handle loader objects/classes
+    elif loader is not None:
         if "Loader" in dir(loader):
             # assume its a module
             code = loader.code_info
@@ -66,7 +97,8 @@ def get_loader(path, loader, **kwargs):
             # assume its a loader object
             loader = loader
             code = type(loader).code_info
-    else:
-        code = identify_code(path)
+    # if no hints or loader was given, test all available
+    if code is None:
+        code = identify_code(path, choices)
         loader = available[code].Loader(path, **kwargs)
     return code, loader

--- a/src/simdata/loaders/__init__.py
+++ b/src/simdata/loaders/__init__.py
@@ -41,10 +41,9 @@ for name in os.listdir(os.path.dirname(os.path.abspath(__file__))):
                   file=sys.stderr)
             raise
 
-
-def identify_code(path):
+def identify_code(path, choices=available):
     code_list = []
-    for key, mod in available.items():
+    for key, mod in choices.items():
         if mod.identify(path):
             code_list.append(key)
     if len(code_list) == 0:

--- a/src/simdata/loaders/fargocpt.py
+++ b/src/simdata/loaders/fargocpt.py
@@ -19,8 +19,8 @@ def identify(path):
     seen_ids = 0
     for root, dirs, files in os.walk(path):
         seen_ids += len([1 for s in identifiers if s in files])
-    if seen_ids >= 2:
-        return True
+        if seen_ids >= 2:
+            return True
     return False
 
 

--- a/src/simdata/loaders/fargocpt.py
+++ b/src/simdata/loaders/fargocpt.py
@@ -96,10 +96,18 @@ def load_scalar(file, var):
 
 def get_data_dir(path):
     rv = None
-    for root, dirs, files in os.walk(path):
-        if "misc.dat" in files:
-            rv = root
-            break
+    # guess first
+    for guess in ["outputs", "output", "out"]:
+        guess_dir = os.path.join(path, guess)
+        if os.path.isfile(os.path.join(guess_dir, "misc.dat")):
+           rv = guess_dir
+           break
+    # now search whole dir tree
+    if rv is None:
+        for root, dirs, files in os.walk(path):
+            if "misc.dat" in files:
+                rv = root
+                break
     if rv is None:
         raise FileNotFoundError(
             "Could not find identifier file 'misc.dat' in any subfolder of '{}'"


### PR DESCRIPTION
Enable giving hints as to what the simulation code is.

Now Data can handle its optional `loader` argument in the following ways:
1. `loader=None` to search all available codes for a match
2. `loader='name'` to select a subset of loaders to match which contain `name` in their name
3. `loader=('name', 'version', 'descriptor')` to select one specific loader which has this tuple as its `module.code` attribute
4. `loader` being a loader object or class

Additionally, the fargocpt loader now first checks some guesses for the output dir before searching the directory tree.