### PR TITLE
Fargo3d mpiio

### DIFF
--- a/src/simdata/loaders/fargo3d/defs.py
+++ b/src/simdata/loaders/fargo3d/defs.py
@@ -351,3 +351,11 @@ alias_particle = {
     "eccentricity": "eccentricity",
     "semi-major axis": "semi-major axis"
 }
+
+mpiio_vars = {
+    "dens" : "mass density",
+    "energy" : "energy density",
+    "vx" : "velocity azimuthal",
+    "vy" : "velocity radial",
+    "vz" : "velocity polar"
+}

--- a/src/simdata/loaders/fargo3d/load2d.py
+++ b/src/simdata/loaders/fargo3d/load2d.py
@@ -6,6 +6,7 @@ import astropy.units as u
 from simdata import grid
 from simdata.loaders import interface
 
+from .loadbinary import load_data
 
 class FieldLoader2d(interface.FieldLoader):
     def load_time(self, n, *args, **kwargs):
@@ -24,9 +25,9 @@ class FieldLoader2d(interface.FieldLoader):
         Nr = self.loader.Nr
         # + (1 if "interfaces" in self.info and "phi" in self.info["interfaces"] else 0)
         Nphi = self.loader.Nphi
-        rv = np.fromfile(self.loader.data_dir +
-                         "/" + self.info["pattern"].format(n)).reshape(
-                             Nr, Nphi) * unit
+        file_path = self.loader.data_dir + "/" + self.info["pattern"].format(n)
+        rv = load_data(file_path, self.info["varname"], n)
+        rv = rv.reshape(Nr, Nphi) * unit
         return rv
 
     def load_grid(self, n):

--- a/src/simdata/loaders/fargo3d/load3d.py
+++ b/src/simdata/loaders/fargo3d/load3d.py
@@ -6,6 +6,7 @@ import astropy.units as u
 from simdata import grid
 from simdata.loaders import interface
 
+from .loadbinary import load_data
 
 class FieldLoader3d(interface.FieldLoader):
     def load_time(self, n, *args, **kwargs):
@@ -26,7 +27,8 @@ class FieldLoader3d(interface.FieldLoader):
         Nphi = self.loader.Nphi
         Ntheta = self.loader.Ntheta
         file_path = self.loader.data_dir + "/" + self.info["pattern"].format(n)
-        rv = np.fromfile(file_path).reshape(Ntheta, Nr, Nphi)
+        rv = load_data(file_path, self.info["varname"], n)
+        rv = rv.reshape(Ntheta, Nr, Nphi)
         rv = np.swapaxes(rv, 0, 2)
         rv = np.swapaxes(rv, 0, 1)
         return rv *unit

--- a/src/simdata/loaders/fargo3d/loadbinary.py
+++ b/src/simdata/loaders/fargo3d/loadbinary.py
@@ -1,0 +1,43 @@
+""" Load binary output data for FARGO3D.
+
+FARGO3D supports different output formats of binary data.
+
+The legacy output format uses separate files for each field.
+The mpiio format saves all fields into a single file.
+
+"""
+import os
+
+import numpy as np
+
+from .mpiio import Fields
+
+
+def load_data(filename, varname, n):
+    """ Load binary data of a variable at step n.
+
+    Output type, legacy or mpiio, is automatically determined using the file extension.
+
+    Parameteters
+    ------------
+    filename : str
+        Path to the data file.
+    varname : str
+        Name of the variable (needed for mpiio format).
+    n : int
+        Output number.
+
+    Returns
+    -------
+    np.array
+        1D flat output array.
+    """
+    file_ext = filename.split(".")[-1]
+    if file_ext == "mpiio":
+        print(f"loading {varname} from mpiio datafile {filename} at output {n}")
+        directory = os.path.dirname(filename)
+        fluidname = os.path.basename(filename).split("_")[0]
+        data = Fields(directory, fluidname, n).get_field(varname)
+    else:
+        data = np.fromfile(filename)
+    return data

--- a/src/simdata/loaders/fargo3d/mpiio.py
+++ b/src/simdata/loaders/fargo3d/mpiio.py
@@ -1,0 +1,64 @@
+""" Module to load output data in the mpiio format.
+
+Taken from the official FARGO3D bitbucket repo https://bitbucket.org/fargo3d/public.
+LICENSE: GNU GPL v3
+"""
+
+from numpy import fromfile
+
+class Fields():
+    def __init__(self, directory, fluid, n, dtype="float64"):
+        """Reading FARGO3D parallel outputs (.mpiio) files.
+        
+        The outputgas.dat/outputdust.dat files are assumed to be in the
+        same directory as the data files.
+        
+        Reading data stored in "directory". The data file corresponds to
+        the fluid "fluid" at output number "n". The data type is given by
+        the "dtype" argument. Possible options are "float64" or
+        "float32".
+        
+        Note: The instantation of the class does not read the file. To get
+        a field, call the method get_field(fieldname).
+        
+        Example:
+        
+        f = Fields("outputs/fargo","gas",0)
+        density = f.get_field("dens").reshape(ny,nx)
+
+        """
+        if len(directory)>1:
+            directory = directory.strip() #We remove possible spaces
+            if directory[-1] != "/": directory += "/"
+        self.name      = fluid
+        self.filename  = fluid + "_" + str(n)+".mpiio"
+        self.directory = directory
+        self.dtype     = dtype
+        self.ifile     = open(directory+self.filename,"r")
+        self.offsets, self.count = self.parse_offsets_file(directory)
+        if dtype == "float64":
+            self.dtype_int = 8
+        else:
+            self.dtype = 4
+        
+    def parse_offsets_file(self,directory):
+        offsets = open(directory+"output{:s}.dat".format(self.name))
+        dict_offset = {}
+        for i,line in enumerate(offsets.readlines()):
+            offset   = int(line.split()[0])
+            fullname = line.split()[1]
+            dict_offset[fullname] = offset
+            if i == 0:
+                count = -1
+            else: #Assuming that all fields have the same count...
+                count = offset-old_offset
+            old_offset = offset
+        offsets.close()
+        return dict_offset,count
+    
+    def get_field(self, fieldname):
+        if fieldname not in["bx","by","bz","divb"]:
+            self.ifile.seek(self.offsets[self.name+fieldname]*self.dtype_int)
+        else:
+            self.ifile.seek(self.offsets[fieldname]*self.dtype_int)
+        return fromfile(self.ifile,count=self.count, dtype=self.dtype)


### PR DESCRIPTION
FARGO3D supports output using MPI write.
Files are then stored in a binary file with the `mpiio` ending.

Documentation can be found [here](https://fargo3d.bitbucket.io/outputs.html#mpi-input-output).

This pull request adds the reader from the FARGO3D utils and provides wrappers to integrate it into simdata and detect the output data.