### PR TITLE
Lazy loading

### DIFF
--- a/src/simdata/data.py
+++ b/src/simdata/data.py
@@ -10,15 +10,38 @@ from . import loaders
 
 class Data:
     """ Create a data interface for the data in 'path' """
-    def __init__(self, path=os.getcwd(), loader=None, **kwargs):
-        self.code, self.loader = loaders.get_loader(path, loader, **kwargs)
+
+    def __init__(self, path=os.getcwd(), loader=None, init_hooks=None, **kwargs):
+        self.path = path
+        self.loader = loader
+        self.kwargs = kwargs
+        self.init_hooks = init_hooks
+
+    def init(self):
+        self.code, self.loader = loaders.get_loader(
+            self.path, self.loader, **self.kwargs)
         self.loader.scout()
         self.fluids = self.loader.fluids
         self.particles = self.loader.particles
-        self.particlegroups = {"particles" : self.particles}
+        self.particlegroups = {"particles": self.particles}
         self.planets = self.loader.planets
         self.parameters = self.loader.parameters
         self.register_postprocessor()
+        if self.init_hooks is not None:
+            for func in self.init_hooks:
+                func()
+
+    def __getattr__(self, attr):
+        try:
+            return self.__dict__[attr]
+        except KeyError:
+            if attr in ["path", "code", "loader", "fluids",
+                        "particles", "particlegroups",
+                        "planets", "paramters"]:
+                self.init()
+                return self.__dict__[attr]
+            else:
+                raise AttributeError(f'{attr}')
 
     def get_fluid(self, name):
         return self.fluids[name]


### PR DESCRIPTION
Only access the data to create loaders one the object is accessed for the first time.

This allows creating many (10s or 100s) of data objects for batch processing without having to wait for a very long time.

It also comes in handy supporting caching of data in plots scripts.